### PR TITLE
Revert "Use SwiftCrypto in replace of the original crypto libraries"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           path: result.json
   test:
     macos:
-      xcode: 11.2.1
+      xcode: 11.0.0 # Specify the Xcode version to use
     steps:
       - checkout
       - run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,39 @@
   "object": {
     "pins": [
       {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto",
+        "package": "CCurve25519",
+        "repositoryURL": "https://github.com/christophhagen/CCurve25519",
         "state": {
           "branch": null,
-          "revision": "9be4a93a76d4b80105044747b35d456de7289c87",
-          "version": "1.0.0"
+          "revision": "f27fa9a2cf0c61a3cb9d9a03b3d3d801ccc64b32",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "CEd25519",
+        "repositoryURL": "https://github.com/christophhagen/CEd25519",
+        "state": {
+          "branch": null,
+          "revision": "9c24d886a9bbc940da973953abb7b2cca02e5d9d",
+          "version": "0.0.6"
+        }
+      },
+      {
+        "package": "CryptoKit25519",
+        "repositoryURL": "https://github.com/christophhagen/CryptoKit25519",
+        "state": {
+          "branch": null,
+          "revision": "d1feb6533039fedc36a4004bd32b328f18a7e653",
+          "version": "0.4.2"
+        }
+      },
+      {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "a44caef0550c346e0ab9172f7c9a3852c1833599",
+          "version": "1.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/apple/swift-crypto", from: "1.0.0")
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.0"),
+    .package(url: "https://github.com/christophhagen/CryptoKit25519", .exact("0.4.2"))
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -18,7 +19,8 @@ let package = Package(
     .target(
       name: "SwiftNoise",
       dependencies: [
-        "Crypto"
+        "CryptoSwift",
+        "CryptoKit25519"
       ]),
     .testTarget(
       name: "SwiftNoiseTests",

--- a/README.md
+++ b/README.md
@@ -81,11 +81,9 @@ The handshake patterns defined in [session 7 of the specification](https://noise
 The following is an example usage for Noise with `Noise_X_25519_AESGCM_SHA256`.
 
 ```swift
-let curveHelper = C25519()
-
-let responderStaticKeyPair = try! curveHelper.generateKeyPair()
-let initiatorEphemeralKeyPair = try! curveHelper.generateKeyPair()
-let responderEphemeralKeyPair = try! curveHelper.generateKeyPair()
+let responderStaticKeyPair = try! generateKeyPair()
+let initiatorEphemeralKeyPair = try! generateKeyPair()
+let responderEphemeralKeyPair = try! generateKeyPair()
 
 let prologue = Data()
 

--- a/Sources/SwiftNoise/Components/Cipher.swift
+++ b/Sources/SwiftNoise/Components/Cipher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crypto
+import CryptoSwift
 
 // https://noiseprotocol.org/noise.html#cipher-functions
 protocol Cipher {
@@ -24,66 +24,55 @@ protocol Cipher {
 }
 
 class AESGCM: Cipher {
-  // A helper method to convert Nonce (which is a 64-bit unsigned integer) to AES.GCM.Nonce.
-  func nonceToAESGCMNonce(n: Nonce) throws -> AES.GCM.Nonce {
-    return try AES.GCM.Nonce(
-      data: [
-        0, 0, 0, 0,
-        UInt8(truncatingIfNeeded: n>>56),
-        UInt8(truncatingIfNeeded: n>>48),
-        UInt8(truncatingIfNeeded: n>>40),
-        UInt8(truncatingIfNeeded: n>>32),
-        UInt8(truncatingIfNeeded: n>>24),
-        UInt8(truncatingIfNeeded: n>>16),
-        UInt8(truncatingIfNeeded: n>>8),
-        UInt8(truncatingIfNeeded: n>>0)
-      ])
+  // A helper method to convert Nonce (which is a 64-bit unsigned integer) to Data.
+  func nonceToData(n: Nonce) -> Data {
+    return Data([
+      0, 0, 0, 0,
+      UInt8(truncatingIfNeeded: n>>56),
+      UInt8(truncatingIfNeeded: n>>48),
+      UInt8(truncatingIfNeeded: n>>40),
+      UInt8(truncatingIfNeeded: n>>32),
+      UInt8(truncatingIfNeeded: n>>24),
+      UInt8(truncatingIfNeeded: n>>16),
+      UInt8(truncatingIfNeeded: n>>8),
+      UInt8(truncatingIfNeeded: n>>0)
+    ])
   }
 
   func encrypt(k: Data, n: Nonce, ad: Data, plaintext: Data) throws -> Data {
-    let nonce = try nonceToAESGCMNonce(n: n)
-    let sealedBox = try AES.GCM.seal(plaintext, using: SymmetricKey(data: k), nonce: nonce, authenticating: ad)
-    return sealedBox.ciphertext + sealedBox.tag
+    let nData = nonceToData(n: n)
+    let gcm = GCM(iv: nData.bytes, additionalAuthenticatedData: ad.bytes, mode: .combined)
+    var cipher: AES
+    do {
+      cipher = try AES(key: k.bytes, blockMode: gcm, padding: .noPadding)
+    } catch {
+      throw CipherError.cannotInstantiateCipher(error: error)
+    }
+    var ciphertext: Data
+    do {
+      ciphertext = Data(try cipher.encrypt(plaintext.bytes))
+    } catch {
+      throw CipherError.invalidPlaintext(error: error)
+    }
+    return ciphertext
   }
 
   func decrypt(k: Data, n: Nonce, ad: Data, ciphertext: Data) throws -> Data {
-    let nonce = try nonceToAESGCMNonce(n: n)
-    let sealedBox = try AES.GCM.SealedBox(combined: nonce + ciphertext)
-    return try AES.GCM.open(sealedBox, using: SymmetricKey(data: k), authenticating: ad)
-  }
-
-  func rekey(k: Data) throws -> Data {
-    return try self.encrypt(k: k, n: 0xffffffffffffffff, ad: Data(), plaintext: Data(repeating: 0, count: 32))
-  }
-}
-
-class CCP: Cipher {
-  // A helper method to convert Nonce (which is a 64-bit unsigned integer) to ChaChaPoly.Nonce.
-  func nonceToChaChaPolyNonce(n: Nonce) throws -> ChaChaPoly.Nonce {
-    return try ChaChaPoly.Nonce(
-      data: [
-        0, 0, 0, 0,
-        UInt8(truncatingIfNeeded: n>>0),
-        UInt8(truncatingIfNeeded: n>>8),
-        UInt8(truncatingIfNeeded: n>>16),
-        UInt8(truncatingIfNeeded: n>>24),
-        UInt8(truncatingIfNeeded: n>>32),
-        UInt8(truncatingIfNeeded: n>>40),
-        UInt8(truncatingIfNeeded: n>>48),
-        UInt8(truncatingIfNeeded: n>>56)
-      ])
-  }
-
-  func encrypt(k: Data, n: Nonce, ad: Data, plaintext: Data) throws -> Data {
-    let nonce = try nonceToChaChaPolyNonce(n: n)
-    let sealedBox = try ChaChaPoly.seal(plaintext, using: SymmetricKey(data: k), nonce: nonce, authenticating: ad)
-    return sealedBox.ciphertext + sealedBox.tag
-  }
-
-  func decrypt(k: Data, n: Nonce, ad: Data, ciphertext: Data) throws -> Data {
-    let nonce = try nonceToChaChaPolyNonce(n: n)
-    let sealedBox = try ChaChaPoly.SealedBox(combined: nonce + ciphertext)
-    return try ChaChaPoly.open(sealedBox, using: SymmetricKey(data: k), authenticating: ad)
+    let nData = nonceToData(n: n)
+    let gcm = GCM(iv: nData.bytes, additionalAuthenticatedData: ad.bytes, mode: .combined)
+    var cipher: AES
+    do {
+      cipher = try AES(key: k.bytes, blockMode: gcm, padding: .noPadding)
+    } catch {
+      throw CipherError.cannotInstantiateCipher(error: error)
+    }
+    var plaintext: Data
+    do {
+      plaintext = Data(try cipher.decrypt(ciphertext.bytes))
+    } catch {
+      throw CipherError.invalidCiphertext(error: error)
+    }
+    return plaintext
   }
 
   func rekey(k: Data) throws -> Data {

--- a/Sources/SwiftNoise/Components/Curve.swift
+++ b/Sources/SwiftNoise/Components/Curve.swift
@@ -1,5 +1,6 @@
 import Foundation
-import Crypto
+import CryptoSwift
+import CryptoKit25519
 
 // https://noiseprotocol.org/noise.html#dh-functions
 public protocol Curve {
@@ -25,11 +26,6 @@ public protocol Curve {
   var dhlen: Int { get }
 }
 
-// An extension on CryptoKit's SharedSecret to return Data
-extension SharedSecret {
-  var data: Data { Data(self.withUnsafeBytes { $0 }) }
-}
-
 public class C25519: Curve {
   public init() {}
 
@@ -48,7 +44,7 @@ public class C25519: Curve {
   }
 
   public func generateKeyPair() throws -> KeyPair {
-    let secretKey = Curve25519.Signing.PrivateKey().rawRepresentation
+    let secretKey = Data(AES.randomIV(32))
     return try constructKeyPair(secretKey: secretKey)
   }
 
@@ -57,7 +53,7 @@ public class C25519: Curve {
       rawRepresentation: Data(normalize(secretKey: keyPair.secretKey)))
     let publicKeyObj = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: Data(publicKey))
     let sharedKey = try secretKeyObj.sharedSecretFromKeyAgreement(with: publicKeyObj)
-    return sharedKey.data
+    return sharedKey.rawData
   }
 
   public var dhlen: Int = 32

--- a/Sources/SwiftNoise/Components/Hash.swift
+++ b/Sources/SwiftNoise/Components/Hash.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crypto
+import CryptoSwift
 
 // https://noiseprotocol.org/noise.html#hash-functions
 protocol Hash {
@@ -25,27 +25,13 @@ protocol Hash {
   var blocklen: Int { get }
 }
 
-// An extension on CryptoKit's SHA256.Digest to return Data
-extension SHA256.Digest {
-  var bytes: [UInt8] { Array(self.makeIterator()) }
-  var data: Data { Data(self.bytes) }
-}
-
-// An extension on CryptoKit's SharedSecret to return Data
-extension HashedAuthenticationCode {
-  var bytes: [UInt8] { Array(self.makeIterator()) }
-  var data: Data { Data(self.bytes) }
-}
-
-class S256: Hash {
+class SHA256: Hash {
   func hash(data: Data) -> Data {
-    let digest = SHA256.hash(data: data)
-    return digest.data
+    return Data(Digest.sha256(data.bytes))
   }
 
-  func hmac(key: Data, data: Data) -> Data {
-    let h = HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key))
-    return h.data
+  func hmac(key: Data, data: Data) throws -> Data {
+    return Data(try HMAC(key: key.bytes, variant: .sha256).authenticate(data.bytes))
   }
 
   func hkdf(chainingKey: Data, inputKeyMaterial: Data, numOutputs: UInt8) throws -> [Data] {
@@ -55,11 +41,11 @@ class S256: Hash {
     if numOutputs > 3 {
       throw HashError.tooManyOutputs
     }
-    let tempKey = self.hmac(key: chainingKey, data: inputKeyMaterial)
+    let tempKey = Data(try self.hmac(key: chainingKey, data: inputKeyMaterial))
     var lastOutput: Data = Data()
     var outputs: [Data] = []
     for index in 1...numOutputs {
-      lastOutput = self.hmac(key: tempKey, data: lastOutput + [index])
+      lastOutput = Data(try self.hmac(key: tempKey, data: lastOutput + [index]))
       outputs.append(lastOutput)
     }
     return outputs

--- a/Sources/SwiftNoise/States/CipherState.swift
+++ b/Sources/SwiftNoise/States/CipherState.swift
@@ -10,7 +10,7 @@ public class CipherState {
 
   var cipherHelper: Cipher
 
-  init(cipherHelper: Cipher, key: Data? = nil) throws {
+  init(key: Data? = nil) throws {
     if key != nil && key!.count != 32 {
       throw CipherStateError.invalidKeySize
     }
@@ -19,7 +19,7 @@ public class CipherState {
     // Sets n = 0.
     self.n = 0
 
-    self.cipherHelper = cipherHelper
+    self.cipherHelper = AESGCM()
   }
   func hasKey() -> Bool {
     // Returns true if k is non-empty, false otherwise.

--- a/Sources/SwiftNoise/States/SymmetricState.swift
+++ b/Sources/SwiftNoise/States/SymmetricState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoSwift
 
 // https://noiseprotocol.org/noise.html#the-symmetricstate-object
 public class SymmetricState {
@@ -9,11 +10,9 @@ public class SymmetricState {
   var cipherState: CipherState
 
   var hashHelper: Hash
-  var cipherHelper: Cipher
 
   init(protocolName: String) throws {
-    self.hashHelper = S256()
-    self.cipherHelper = AESGCM()
+    self.hashHelper = SHA256()
 
     // If protocol_name is less than or equal to HASHLEN bytes in length,
     // sets h equal to protocol_name with zero bytes appended to make HASHLEN bytes.
@@ -28,7 +27,7 @@ public class SymmetricState {
     self.ck = self.h
 
     // Calls InitializeKey(empty).
-    self.cipherState = try CipherState(cipherHelper: self.cipherHelper)
+    self.cipherState = try CipherState()
   }
   func mixKey(inputKeyMaterial: Data) throws {
     // Sets ck, temp_k = HKDF(ck, input_key_material, 2).
@@ -39,7 +38,7 @@ public class SymmetricState {
     // If HASHLEN is 64, then truncates temp_k to 32 bytes.
 
     // Calls InitializeKey(temp_k).
-    self.cipherState = try CipherState(cipherHelper: self.cipherHelper, key: tempK)
+    self.cipherState = try CipherState(key: tempK)
   }
   func mixHash(data: Data) {
     // Sets h = HASH(h || data)
@@ -58,7 +57,7 @@ public class SymmetricState {
     // If HASHLEN is 64, then truncates temp_k to 32 bytes.
 
     // Calls InitializeKey(temp_k).
-    self.cipherState = try CipherState(cipherHelper: self.cipherHelper, key: tempK)
+    self.cipherState = try CipherState(key: tempK)
   }
   func getHandshakeHash() -> Data {
     // Returns h.
@@ -88,8 +87,8 @@ public class SymmetricState {
 
     // Creates two new CipherState objects c1 and c2.
     // Calls c1.InitializeKey(temp_k1) and c2.InitializeKey(temp_k2).
-    let c1 = try CipherState(cipherHelper: self.cipherHelper, key: tempK1)
-    let c2 = try CipherState(cipherHelper: self.cipherHelper, key: tempK2)
+    let c1 = try CipherState(key: tempK1)
+    let c2 = try CipherState(key: tempK2)
 
     // Returns the pair (c1, c2).
     return (c1, c2)

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -168,25 +168,6 @@ extension Message: Decodable {
   }
 }
 
-// Reference: https://github.com/krzyzanowskim/CryptoSwift/issues/546#issuecomment-349220335
-extension Data {
-  init?(hex: String) {
-    let length = hex.count / 2
-    var data = Data(capacity: length)
-    for i in 0 ..< length {
-      let j = hex.index(hex.startIndex, offsetBy: i * 2)
-      let k = hex.index(j, offsetBy: 2)
-      let bytes = hex[j..<k]
-      if var byte = UInt8(bytes, radix: 16) {
-        data.append(&byte, count: 1)
-      } else {
-        return nil
-      }
-    }
-    self = data
-  }
-}
-
 extension KeyedDecodingContainer {
   func decodeHex(forKey key: Key) throws -> Data? {
     if !self.contains(key) {


### PR DESCRIPTION
Reverts samueltangz/swift-noise-protocol#9 as SwiftCrypto requires macOS 10.15 (which, however, didn't work on the CI machine even if it is 10.15.3).