### PR TITLE
Add swift-format.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ targets: (
 import SwiftNoise
 ```
 
-
-
 ## Supported features
 
 ### DH functions, cipher functions, and hash functions
@@ -107,3 +105,12 @@ let initiatorTx = try! initiatorState.writeMessage(payload: Data())
 assert(try! responderState.readMessage(message: initiatorTx) == Data())
 assert(responderState.remoteE! == initiatorEphemeralKeyPair.publicKey)
 ```
+
+# Development
+
+## Code Format
+
+We use swift-format for automatic code formatting.
+
+ - Download via homebrew: `brew install swift-format`
+ - Run formatter: `swift-format -i --configuration=swift-format.json */**/**/*.swift`

--- a/Sources/SwiftNoise/Components/Cipher.swift
+++ b/Sources/SwiftNoise/Components/Cipher.swift
@@ -28,14 +28,14 @@ class AESGCM: Cipher {
   func nonceToData(n: Nonce) -> Data {
     return Data([
       0, 0, 0, 0,
-      UInt8(truncatingIfNeeded: n>>56),
-      UInt8(truncatingIfNeeded: n>>48),
-      UInt8(truncatingIfNeeded: n>>40),
-      UInt8(truncatingIfNeeded: n>>32),
-      UInt8(truncatingIfNeeded: n>>24),
-      UInt8(truncatingIfNeeded: n>>16),
-      UInt8(truncatingIfNeeded: n>>8),
-      UInt8(truncatingIfNeeded: n>>0)
+      UInt8(truncatingIfNeeded: n >> 56),
+      UInt8(truncatingIfNeeded: n >> 48),
+      UInt8(truncatingIfNeeded: n >> 40),
+      UInt8(truncatingIfNeeded: n >> 32),
+      UInt8(truncatingIfNeeded: n >> 24),
+      UInt8(truncatingIfNeeded: n >> 16),
+      UInt8(truncatingIfNeeded: n >> 8),
+      UInt8(truncatingIfNeeded: n >> 0),
     ])
   }
 

--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -33,8 +33,8 @@ func getEphemeralKey(e: KeyPair?, re: PublicKey?, own: Bool) throws -> PublicKey
 }
 
 public enum Key {
-  case e // Ephemeral key
-  case s // Static key
+  case e  // Ephemeral key
+  case s  // Static key
 }
 
 // https://noiseprotocol.org/noise.html#the-handshakestate-object
@@ -57,12 +57,12 @@ public class HandshakeState {
   var curveHelper: Curve
 
   #if DEBUG
-  public var remoteS: PublicKey? {
-    return rs
-  }
-  public var remoteE: PublicKey? {
-    return re
-  }
+    public var remoteS: PublicKey? {
+      return rs
+    }
+    public var remoteE: PublicKey? {
+      return re
+    }
   #endif
 
   // Returns a public key according to the arguments:
@@ -115,8 +115,10 @@ public class HandshakeState {
     throw HandshakeStateError.invalidKey
   }
 
-  public init(pattern: HandshakePattern, initiator: Bool, prologue: Data = Data(), s: KeyPair? = nil,
-              e: KeyPair? = nil, rs: PublicKey? = nil, re: PublicKey? = nil) throws {
+  public init(
+    pattern: HandshakePattern, initiator: Bool, prologue: Data = Data(), s: KeyPair? = nil,
+    e: KeyPair? = nil, rs: PublicKey? = nil, re: PublicKey? = nil
+  ) throws {
     // Derives a protocol_name byte sequence by combining the names for the handshake pattern and
     // crypto functions, as specified in Section 8. Calls InitializeSymmetric(protocol_name).
     let protocolName = "Noise_\(pattern)_25519_AESGCM_SHA256"
@@ -180,9 +182,9 @@ extension HandshakeState {
   // buffer. Calls MixHash(e.public_key).
   private func writeE() throws -> Data {
     #if !DEBUG
-    if self.e != nil {
-      throw HandshakeStateError.ephemeralKeyAlreadyExist
-    }
+      if self.e != nil {
+        throw HandshakeStateError.ephemeralKeyAlreadyExist
+      }
     #endif
     let e = try self.e ?? self.curveHelper.generateKeyPair()
     self.e = e

--- a/Sources/SwiftNoise/States/SymmetricState.swift
+++ b/Sources/SwiftNoise/States/SymmetricState.swift
@@ -19,7 +19,7 @@ public class SymmetricState {
     // Otherwise sets h = HASH(protocol_name).
     let h = Data(protocolName.utf8)
     if h.count <= 32 {
-      self.h = h + Data(repeating: 0, count: 32-h.count)
+      self.h = h + Data(repeating: 0, count: 32 - h.count)
     } else {
       self.h = self.hashHelper.hash(data: h)
     }

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -60,122 +60,122 @@ struct PatternDetails {
 let patterns: [HandshakePattern: PatternDetails] = [
   .N: PatternDetails(
     initiatorPremessages: [],
-    responderPremessages: [ .s ],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es ]
+      [.e, .es]
     ]
   ),
   .K: PatternDetails(
-    initiatorPremessages: [ .s ],
-    responderPremessages: [ .s ],
+    initiatorPremessages: [.s],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es, .ss ]
+      [.e, .es, .ss]
     ]
   ),
   .X: PatternDetails(
     initiatorPremessages: [],
-    responderPremessages: [ .s ],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es, .s, .ss ]
+      [.e, .es, .s, .ss]
     ]
   ),
   .NN: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee ]
+      [.e],
+      [.e, .ee],
     ]
   ),
   .NK: PatternDetails(
     initiatorPremessages: [],
-    responderPremessages: [ .s ],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es ],
-      [ .e, .ee ]
+      [.e, .es],
+      [.e, .ee],
     ]
   ),
   .NX: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee, .s, .es ]
+      [.e],
+      [.e, .ee, .s, .es],
     ]
   ),
   .KN: PatternDetails(
-    initiatorPremessages: [ .s ],
+    initiatorPremessages: [.s],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee, .se ]
+      [.e],
+      [.e, .ee, .se],
     ]
   ),
   .KK: PatternDetails(
-    initiatorPremessages: [ .s ],
-    responderPremessages: [ .s ],
+    initiatorPremessages: [.s],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es, .ss ],
-      [ .e, .ee, .se ]
+      [.e, .es, .ss],
+      [.e, .ee, .se],
     ]
   ),
   .KX: PatternDetails(
-    initiatorPremessages: [ .s ],
+    initiatorPremessages: [.s],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee, .se, .s, .es ]
+      [.e],
+      [.e, .ee, .se, .s, .es],
     ]
   ),
   .XN: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee ],
-      [ .s, .se ]
+      [.e],
+      [.e, .ee],
+      [.s, .se],
     ]
   ),
   .XK: PatternDetails(
     initiatorPremessages: [],
-    responderPremessages: [ .s ],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es ],
-      [ .e, .ee ],
-      [ .s, .se ]
+      [.e, .es],
+      [.e, .ee],
+      [.s, .se],
     ]
   ),
   .XX: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e ],
-      [ .e, .ee, .s, .es ],
-      [ .s, .se ]
+      [.e],
+      [.e, .ee, .s, .es],
+      [.s, .se],
     ]
   ),
   .IN: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e, .s ],
-      [ .e, .ee, .se ]
+      [.e, .s],
+      [.e, .ee, .se],
     ]
   ),
   .IK: PatternDetails(
     initiatorPremessages: [],
-    responderPremessages: [ .s ],
+    responderPremessages: [.s],
     messagePatterns: [
-      [ .e, .es, .s, .ss ],
-      [ .e, .ee, .se ]
+      [.e, .es, .s, .ss],
+      [.e, .ee, .se],
     ]
   ),
   .IX: PatternDetails(
     initiatorPremessages: [],
     responderPremessages: [],
     messagePatterns: [
-      [ .e, .s ],
-      [ .e, .ee, .se, .s, .es ]
+      [.e, .s],
+      [.e, .ee, .se, .s, .es],
     ]
-  )
+  ),
 ]

--- a/Sources/SwiftNoise/SwiftNoiseError.swift
+++ b/Sources/SwiftNoise/SwiftNoiseError.swift
@@ -1,6 +1,6 @@
 enum HandshakeStateError: Error {
-  case invalidPattern // should not happen in normal use case
-  case invalidKey // should not happen in normal use case
+  case invalidPattern  // should not happen in normal use case
+  case invalidKey  // should not happen in normal use case
   case invalidPremessagePattern
   case invalidMessagePattern
   case missingStaticKey

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -32,7 +32,7 @@ final class SwiftNoiseTests: XCTestCase {
     "Noise_XX_25519_AESGCM_SHA256",
     "Noise_IN_25519_AESGCM_SHA256",
     "Noise_IK_25519_AESGCM_SHA256",
-    "Noise_IX_25519_AESGCM_SHA256"
+    "Noise_IX_25519_AESGCM_SHA256",
   ]
 
   func testSnowVectors() throws {

--- a/Tests/SwiftNoiseTests/XCTestManifests.swift
+++ b/Tests/SwiftNoiseTests/XCTestManifests.swift
@@ -1,9 +1,9 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-  return [
-    testCase(SwiftNoiseTests.allTests)
-  ]
-}
+  public func allTests() -> [XCTestCaseEntry] {
+    return [
+      testCase(SwiftNoiseTests.allTests)
+    ]
+  }
 #endif

--- a/swift-format.json
+++ b/swift-format.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "indentation": {
+    "spaces": 2,
+  },
+  "lineLength": 200,
+  "rules": {
+    "OrderedImports": false,
+    "NoEmptyTrailingClosureParentheses": false,
+  },
+}


### PR DESCRIPTION
Requires https://github.com/samueltangz/swift-noise-protocol/pull/15 is merged first

---

- This PR adds a basic `swift-format.json` file for use with [swift-format](https://github.com/apple/swift-format)
- It mostly follows the existing rules for the code in the repo
- It means new developers can contribute code and it match the existing code style
