### PR TITLE
Update project to use apple/swift-crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,39 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "CCurve25519",
-        "repositoryURL": "https://github.com/christophhagen/CCurve25519",
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "f27fa9a2cf0c61a3cb9d9a03b3d3d801ccc64b32",
-          "version": "1.0.4"
-        }
-      },
-      {
-        "package": "CEd25519",
-        "repositoryURL": "https://github.com/christophhagen/CEd25519",
-        "state": {
-          "branch": null,
-          "revision": "9c24d886a9bbc940da973953abb7b2cca02e5d9d",
-          "version": "0.0.6"
-        }
-      },
-      {
-        "package": "CryptoKit25519",
-        "repositoryURL": "https://github.com/christophhagen/CryptoKit25519",
-        "state": {
-          "branch": null,
-          "revision": "d1feb6533039fedc36a4004bd32b328f18a7e653",
-          "version": "0.4.2"
-        }
-      },
-      {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "a44caef0550c346e0ab9172f7c9a3852c1833599",
-          "version": "1.3.0"
+          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
+          "version": "1.1.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,22 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
   name: "SwiftNoise",
+  platforms: [
+    .macOS(.v10_15),
+    .iOS(.v13),
+    .watchOS(.v6),
+    .tvOS(.v13),
+  ],
   products: [
     .library(name: "SwiftNoise", targets: ["SwiftNoise"])
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.0"),
-    .package(url: "https://github.com/christophhagen/CryptoKit25519", .exact("0.4.2"))
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -19,13 +24,14 @@ let package = Package(
     .target(
       name: "SwiftNoise",
       dependencies: [
-        "CryptoSwift",
-        "CryptoKit25519"
+        .product(name: "Crypto", package: "swift-crypto")
       ]),
     .testTarget(
       name: "SwiftNoiseTests",
-      dependencies: [
-        "SwiftNoise"
-      ])
+      dependencies: ["SwiftNoise"],
+      resources: [
+        .copy("SnowTestVectors.json")
+      ]
+    )
   ]
 )

--- a/Sources/SwiftNoise/Components/Cipher.swift
+++ b/Sources/SwiftNoise/Components/Cipher.swift
@@ -1,8 +1,8 @@
 import Foundation
-import CryptoSwift
+import Crypto
 
 // https://noiseprotocol.org/noise.html#cipher-functions
-protocol Cipher {
+public protocol Cipher {
   // Encrypts plaintext using the cipher key k of 32 bytes and an 8-byte unsigned integer nonce n
   // which must be unique for the key k. Returns the ciphertext. Encryption must be done with an
   // "AEAD" encryption mode with the associated data ad (using the terminology from [1]) and
@@ -23,59 +23,52 @@ protocol Cipher {
   func rekey(k: Data) throws -> Data
 }
 
-class AESGCM: Cipher {
-  // A helper method to convert Nonce (which is a 64-bit unsigned integer) to Data.
-  func nonceToData(n: Nonce) -> Data {
-    return Data([
-      0, 0, 0, 0,
-      UInt8(truncatingIfNeeded: n >> 56),
-      UInt8(truncatingIfNeeded: n >> 48),
-      UInt8(truncatingIfNeeded: n >> 40),
-      UInt8(truncatingIfNeeded: n >> 32),
-      UInt8(truncatingIfNeeded: n >> 24),
-      UInt8(truncatingIfNeeded: n >> 16),
-      UInt8(truncatingIfNeeded: n >> 8),
-      UInt8(truncatingIfNeeded: n >> 0),
-    ])
+public enum Ciphers {
+  public static func cipher(named name: String) -> Cipher? {
+    switch name {
+    case "AESGCM":
+      return Ciphers.AESGCM()
+    default:
+      return nil
+    }
+  }
+}
+
+extension Ciphers {
+  struct AESGCM: Cipher {
+
+    // A helper method to convert Nonce (which is a 64-bit unsigned integer) to Data.
+    func nonceToData(n: Nonce) -> Data {
+      var be = CFSwapInt64HostToBig(n)
+      let data = Data(bytes: &be, count: MemoryLayout<UInt64>.size)
+
+      let padding = Data(repeating: 0, count: 4)
+      return padding + data
+    }
+
+    func encrypt(k: Data, n: Nonce, ad: Data, plaintext: Data) throws -> Data {
+      let key = SymmetricKey(data: k)
+      let nonce = try AES.GCM.Nonce(data: nonceToData(n: n))
+      let box = try AES.GCM.seal(plaintext, using: key, nonce: nonce, authenticating: ad)
+
+      return box.ciphertext + box.tag
+    }
+
+    func decrypt(k: Data, n: Nonce, ad: Data, ciphertext: Data) throws -> Data {
+      let key = SymmetricKey(data: k)
+      let nonce = try AES.GCM.Nonce(data: nonceToData(n: n))
+
+      let ctext = ciphertext.prefix(ciphertext.count - 16)
+      let tag = ciphertext.suffix(16)
+
+      let box = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ctext, tag: tag)
+
+      return try AES.GCM.open(box, using: key, authenticating: ad)
+    }
+
+    func rekey(k: Data) throws -> Data {
+      return try self.encrypt(k: k, n: 0xffffffffffffffff, ad: Data(), plaintext: Data(repeating: 0, count: 32))
+    }
   }
 
-  func encrypt(k: Data, n: Nonce, ad: Data, plaintext: Data) throws -> Data {
-    let nData = nonceToData(n: n)
-    let gcm = GCM(iv: nData.bytes, additionalAuthenticatedData: ad.bytes, mode: .combined)
-    var cipher: AES
-    do {
-      cipher = try AES(key: k.bytes, blockMode: gcm, padding: .noPadding)
-    } catch {
-      throw CipherError.cannotInstantiateCipher(error: error)
-    }
-    var ciphertext: Data
-    do {
-      ciphertext = Data(try cipher.encrypt(plaintext.bytes))
-    } catch {
-      throw CipherError.invalidPlaintext(error: error)
-    }
-    return ciphertext
-  }
-
-  func decrypt(k: Data, n: Nonce, ad: Data, ciphertext: Data) throws -> Data {
-    let nData = nonceToData(n: n)
-    let gcm = GCM(iv: nData.bytes, additionalAuthenticatedData: ad.bytes, mode: .combined)
-    var cipher: AES
-    do {
-      cipher = try AES(key: k.bytes, blockMode: gcm, padding: .noPadding)
-    } catch {
-      throw CipherError.cannotInstantiateCipher(error: error)
-    }
-    var plaintext: Data
-    do {
-      plaintext = Data(try cipher.decrypt(ciphertext.bytes))
-    } catch {
-      throw CipherError.invalidCiphertext(error: error)
-    }
-    return plaintext
-  }
-
-  func rekey(k: Data) throws -> Data {
-    return try self.encrypt(k: k, n: 0xffffffffffffffff, ad: Data(), plaintext: Data(repeating: 0, count: 32))
-  }
 }

--- a/Sources/SwiftNoise/Components/Cipher.swift
+++ b/Sources/SwiftNoise/Components/Cipher.swift
@@ -49,19 +49,15 @@ extension Ciphers {
     func encrypt(k: Data, n: Nonce, ad: Data, plaintext: Data) throws -> Data {
       let key = SymmetricKey(data: k)
       let nonce = try AES.GCM.Nonce(data: nonceToData(n: n))
-      let box = try AES.GCM.seal(plaintext, using: key, nonce: nonce, authenticating: ad)
 
+      let box = try AES.GCM.seal(plaintext, using: key, nonce: nonce, authenticating: ad)
       return box.ciphertext + box.tag
     }
 
     func decrypt(k: Data, n: Nonce, ad: Data, ciphertext: Data) throws -> Data {
       let key = SymmetricKey(data: k)
       let nonce = try AES.GCM.Nonce(data: nonceToData(n: n))
-
-      let ctext = ciphertext.prefix(ciphertext.count - 16)
-      let tag = ciphertext.suffix(16)
-
-      let box = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ctext, tag: tag)
+      let box = try AES.GCM.SealedBox(combined: nonce + ciphertext)
 
       return try AES.GCM.open(box, using: key, authenticating: ad)
     }

--- a/Sources/SwiftNoise/Components/Curve.swift
+++ b/Sources/SwiftNoise/Components/Curve.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CryptoSwift
-import CryptoKit25519
+import Crypto
 
 // https://noiseprotocol.org/noise.html#dh-functions
 public protocol Curve {
@@ -26,35 +25,49 @@ public protocol Curve {
   var dhlen: Int { get }
 }
 
-public class C25519: Curve {
-  public init() {}
+func randomKey(_ count: Int) -> SecretKey {
+  let bytes = (0..<count).map({ _ in UInt8.random(in: 0...UInt8.max) })
+  return Data(bytes)
+}
 
-  func normalize(secretKey: SecretKey) -> SecretKey {
-    var newSecretKey = secretKey
-    newSecretKey[0] &= 0xf8
-    newSecretKey[31] &= 0x3f
-    newSecretKey[31] |= 0x40
-    return newSecretKey
+public enum Curves {
+  public static func curve(named name: String) -> Curve? {
+    switch name {
+    case "25519":
+      return C25519()
+    default:
+      return nil
+    }
+  }
+}
+
+extension Curves {
+  public struct C25519: Curve {
+    public init() {}
+
+    public let dhlen: Int = 32
+
+    public func constructKeyPair(secretKey: SecretKey) throws -> KeyPair {
+      let secretKeyObj = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: secretKey)
+      let publicKey = secretKeyObj.publicKey.rawRepresentation
+
+      return KeyPair(publicKey: publicKey, secretKey: secretKey)
+    }
+
+    public func generateKeyPair() throws -> KeyPair {
+      let secretKey = randomKey(self.dhlen)
+      return try constructKeyPair(secretKey: secretKey)
+    }
+
+    public func dh(keyPair: KeyPair, publicKey: PublicKey) throws -> Data {
+      let secretKeyObj = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: keyPair.secretKey)
+      let publicKeyObj = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: publicKey)
+      let sharedKey = try secretKeyObj.sharedSecretFromKeyAgreement(with: publicKeyObj)
+
+      return sharedKey.withUnsafeBytes { ptr in
+        return Data(ptr)
+      }
+    }
   }
 
-  public func constructKeyPair(secretKey: SecretKey) throws -> KeyPair {
-    let secretKeyObj = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: Data(normalize(secretKey: secretKey)))
-    let publicKey = secretKeyObj.publicKey.rawRepresentation
-    return KeyPair(publicKey: publicKey, secretKey: secretKey)
-  }
-
-  public func generateKeyPair() throws -> KeyPair {
-    let secretKey = Data(AES.randomIV(32))
-    return try constructKeyPair(secretKey: secretKey)
-  }
-
-  public func dh(keyPair: KeyPair, publicKey: PublicKey) throws -> Data {
-    let secretKeyObj = try Curve25519.KeyAgreement.PrivateKey(
-      rawRepresentation: Data(normalize(secretKey: keyPair.secretKey)))
-    let publicKeyObj = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: Data(publicKey))
-    let sharedKey = try secretKeyObj.sharedSecretFromKeyAgreement(with: publicKeyObj)
-    return sharedKey.rawData
-  }
-
-  public var dhlen: Int = 32
 }

--- a/Sources/SwiftNoise/Components/DHFunction.swift
+++ b/Sources/SwiftNoise/Components/DHFunction.swift
@@ -2,7 +2,7 @@ import Foundation
 import Crypto
 
 // https://noiseprotocol.org/noise.html#dh-functions
-public protocol Curve {
+public protocol DHFunction {
   func constructKeyPair(secretKey: SecretKey) throws -> KeyPair
 
   // Generates a new Diffie-Hellman key pair. A DH key pair consists of public_key and private_key
@@ -30,8 +30,8 @@ func randomKey(_ count: Int) -> SecretKey {
   return Data(bytes)
 }
 
-public enum Curves {
-  public static func curve(named name: String) -> Curve? {
+public enum DHFunctions {
+  public static func dhFunction(named name: String) -> DHFunction? {
     switch name {
     case "25519":
       return C25519()
@@ -41,8 +41,8 @@ public enum Curves {
   }
 }
 
-extension Curves {
-  public struct C25519: Curve {
+extension DHFunctions {
+  public struct C25519: DHFunction {
     public init() {}
 
     public let dhlen: Int = 32

--- a/Sources/SwiftNoise/States/CipherState.swift
+++ b/Sources/SwiftNoise/States/CipherState.swift
@@ -9,7 +9,7 @@ public class CipherState {
   // n: An 8-byte (64-bit) unsigned integer nonce.
   private var n: Nonce
 
-  private let cipherHelper: Cipher
+  private let cipherFunction: Cipher
 
   init(key: Data? = nil) throws {
     if key != nil && key!.count != 32 {
@@ -20,7 +20,7 @@ public class CipherState {
     // Sets n = 0.
     self.n = 0
 
-    self.cipherHelper = Ciphers.AESGCM()
+    self.cipherFunction = Ciphers.AESGCM()
   }
 
   func hasKey() -> Bool {
@@ -38,7 +38,7 @@ public class CipherState {
     if !self.hasKey() {
       return plaintext
     }
-    let ciphertext = try self.cipherHelper.encrypt(k: self.k!, n: self.n, ad: ad, plaintext: plaintext)
+    let ciphertext = try self.cipherFunction.encrypt(k: self.k!, n: self.n, ad: ad, plaintext: plaintext)
     try self.n.increment()
     return ciphertext
   }
@@ -50,13 +50,13 @@ public class CipherState {
     if !self.hasKey() {
       return ciphertext
     }
-    let plaintext = try self.cipherHelper.decrypt(k: self.k!, n: self.n, ad: ad, ciphertext: ciphertext)
+    let plaintext = try self.cipherFunction.decrypt(k: self.k!, n: self.n, ad: ad, ciphertext: ciphertext)
     try self.n.increment()
     return plaintext
   }
 
   func rekey() throws {
     // Sets k = REKEY(k).
-    self.k = try self.cipherHelper.rekey(k: self.k!)
+    self.k = try self.cipherFunction.rekey(k: self.k!)
   }
 }

--- a/Sources/SwiftNoise/States/CipherState.swift
+++ b/Sources/SwiftNoise/States/CipherState.swift
@@ -2,13 +2,14 @@ import Foundation
 
 // https://noiseprotocol.org/noise.html#the-cipherstate-object
 public class CipherState {
+
   // k: A cipher key of 32 bytes (which may be empty). Empty is a special value which indicates k
   // has not yet been initialized.
-  var k: Data?
+  private var k: Data?
   // n: An 8-byte (64-bit) unsigned integer nonce.
-  var n: Nonce
+  private var n: Nonce
 
-  var cipherHelper: Cipher
+  private let cipherHelper: Cipher
 
   init(key: Data? = nil) throws {
     if key != nil && key!.count != 32 {
@@ -19,16 +20,19 @@ public class CipherState {
     // Sets n = 0.
     self.n = 0
 
-    self.cipherHelper = AESGCM()
+    self.cipherHelper = Ciphers.AESGCM()
   }
+
   func hasKey() -> Bool {
     // Returns true if k is non-empty, false otherwise.
     return k != nil
   }
+
   func setNonce(nonce: Nonce) {
     // Sets n = nonce.
     self.n = nonce
   }
+
   public func encryptWithAd(ad: Data, plaintext: Data) throws -> Data {
     // If k is non-empty returns ENCRYPT(k, n++, ad, plaintext). Otherwise returns plaintext.
     if !self.hasKey() {
@@ -38,6 +42,7 @@ public class CipherState {
     try self.n.increment()
     return ciphertext
   }
+
   public func decryptWithAd(ad: Data, ciphertext: Data) throws -> Data {
     // If k is non-empty returns DECRYPT(k, n++, ad, ciphertext). Otherwise returns ciphertext. If
     // an authentication failure occurs in DECRYPT() then n is not incremented and an error is
@@ -49,6 +54,7 @@ public class CipherState {
     try self.n.increment()
     return plaintext
   }
+
   func rekey() throws {
     // Sets k = REKEY(k).
     self.k = try self.cipherHelper.rekey(k: self.k!)

--- a/Sources/SwiftNoise/States/CipherState.swift
+++ b/Sources/SwiftNoise/States/CipherState.swift
@@ -33,7 +33,7 @@ public class CipherState {
     self.n = nonce
   }
 
-  public func encryptWithAd(ad: Data, plaintext: Data) throws -> Data {
+  public func encrypt(plaintext: Data, with ad: Data = Data()) throws -> Data {
     // If k is non-empty returns ENCRYPT(k, n++, ad, plaintext). Otherwise returns plaintext.
     if !self.hasKey() {
       return plaintext
@@ -43,7 +43,7 @@ public class CipherState {
     return ciphertext
   }
 
-  public func decryptWithAd(ad: Data, ciphertext: Data) throws -> Data {
+  public func decrypt(ciphertext: Data, with ad: Data = Data()) throws -> Data {
     // If k is non-empty returns DECRYPT(k, n++, ad, ciphertext). Otherwise returns ciphertext. If
     // an authentication failure occurs in DECRYPT() then n is not incremented and an error is
     // signaled to the caller.

--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -54,7 +54,7 @@ public class HandshakeState {
   var messagePatterns: [[Token]]
   var symmetricState: SymmetricState
 
-  var curveHelper: Curve
+  let dhFunction: Curve
 
   #if DEBUG
     public var remoteS: PublicKey? {
@@ -124,7 +124,7 @@ public class HandshakeState {
     let protocolName = "Noise_\(pattern)_25519_AESGCM_SHA256"
     self.symmetricState = try SymmetricState(protocolName: protocolName)
 
-    self.curveHelper = Curves.C25519()
+    self.dhFunction = Curves.C25519()
 
     // Calls MixHash(prologue).
     self.symmetricState.mixHash(data: prologue)
@@ -187,7 +187,7 @@ extension HandshakeState {
         throw HandshakeStateError.ephemeralKeyAlreadyExist
       }
     #endif
-    let e = try self.e ?? self.curveHelper.generateKeyPair()
+    let e = try self.e ?? self.dhFunction.generateKeyPair()
     self.e = e
     self.symmetricState.mixHash(data: e.publicKey)
     return e.publicKey
@@ -203,7 +203,7 @@ extension HandshakeState {
   private func writeEE() throws -> Data {
     let e = try self.getKeyPair(key: .e)
     let re = try self.getPublicKey(own: false, key: .e)
-    let dh = try self.curveHelper.dh(keyPair: e, publicKey: re)
+    let dh = try self.dhFunction.dh(keyPair: e, publicKey: re)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
@@ -212,7 +212,7 @@ extension HandshakeState {
   private func writeES() throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .e : .s)
     let remotePublicKey = try self.getPublicKey(own: false, key: self.initiator ? .s : .e)
-    let dh = try self.curveHelper.dh(keyPair: keyPair, publicKey: remotePublicKey)
+    let dh = try self.dhFunction.dh(keyPair: keyPair, publicKey: remotePublicKey)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
@@ -221,7 +221,7 @@ extension HandshakeState {
   private func writeSE() throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .s : .e)
     let remotePublicKey = try self.getPublicKey(own: false, key: self.initiator ? .e : .s)
-    let dh = try self.curveHelper.dh(keyPair: keyPair, publicKey: remotePublicKey)
+    let dh = try self.dhFunction.dh(keyPair: keyPair, publicKey: remotePublicKey)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
@@ -230,7 +230,7 @@ extension HandshakeState {
   private func writeSS() throws -> Data {
     let s = try self.getKeyPair(key: .s)
     let rs = try self.getPublicKey(own: false, key: .s)
-    let dh = try self.curveHelper.dh(keyPair: s, publicKey: rs)
+    let dh = try self.dhFunction.dh(keyPair: s, publicKey: rs)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
@@ -285,7 +285,7 @@ extension HandshakeState {
   private func readEE(_ messageBuffer: Data) throws -> Data {
     let e = try self.getKeyPair(key: .e)
     let re = try self.getPublicKey(own: false, key: .e)
-    let dh = try self.curveHelper.dh(keyPair: e, publicKey: re)
+    let dh = try self.dhFunction.dh(keyPair: e, publicKey: re)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
@@ -294,7 +294,7 @@ extension HandshakeState {
   private func readES(_ messageBuffer: Data) throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .e : .s)
     let remotePublicKey = try self.getPublicKey(own: false, key: self.initiator ? .s : .e)
-    let dh = try self.curveHelper.dh(keyPair: keyPair, publicKey: remotePublicKey)
+    let dh = try self.dhFunction.dh(keyPair: keyPair, publicKey: remotePublicKey)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
@@ -303,7 +303,7 @@ extension HandshakeState {
   private func readSE(_ messageBuffer: Data) throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .s : .e)
     let remotePublicKey = try self.getPublicKey(own: false, key: self.initiator ? .e : .s)
-    let dh = try self.curveHelper.dh(keyPair: keyPair, publicKey: remotePublicKey)
+    let dh = try self.dhFunction.dh(keyPair: keyPair, publicKey: remotePublicKey)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
@@ -312,7 +312,7 @@ extension HandshakeState {
   private func readSS(_ messageBuffer: Data) throws -> Data {
     let s = try self.getKeyPair(key: .s)
     let rs = try self.getPublicKey(own: false, key: .s)
-    let dh = try self.curveHelper.dh(keyPair: s, publicKey: rs)
+    let dh = try self.dhFunction.dh(keyPair: s, publicKey: rs)
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }

--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -54,7 +54,7 @@ public class HandshakeState {
   var messagePatterns: [[Token]]
   var symmetricState: SymmetricState
 
-  let dhFunction: Curve
+  let dhFunction: DHFunction
 
   #if DEBUG
     public var remoteS: PublicKey? {
@@ -124,7 +124,7 @@ public class HandshakeState {
     let protocolName = "Noise_\(pattern)_25519_AESGCM_SHA256"
     self.symmetricState = try SymmetricState(protocolName: protocolName)
 
-    self.dhFunction = Curves.C25519()
+    self.dhFunction = DHFunctions.C25519()
 
     // Calls MixHash(prologue).
     self.symmetricState.mixHash(data: prologue)

--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -117,7 +117,7 @@ public class HandshakeState {
 
   public init(
     pattern: HandshakePattern, initiator: Bool, prologue: Data = Data(), s: KeyPair? = nil,
-    e: KeyPair? = nil, rs: PublicKey? = nil, re: PublicKey? = nil
+    e: KeyPair? = nil, rs: PublicKey? = nil
   ) throws {
     // Derives a protocol_name byte sequence by combining the names for the handshake pattern and
     // crypto functions, as specified in Section 8. Calls InitializeSymmetric(protocol_name).
@@ -134,7 +134,7 @@ public class HandshakeState {
     self.s = s
     self.e = e
     self.rs = rs
-    self.re = re
+    self.re = nil
 
     // Calls MixHash() once for each public key listed in the pre-messages from handshake_pattern,
     // with the specified public key as input (see Section 7 for an explanation of pre-messages).

--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -124,7 +124,7 @@ public class HandshakeState {
     let protocolName = "Noise_\(pattern)_25519_AESGCM_SHA256"
     self.symmetricState = try SymmetricState(protocolName: protocolName)
 
-    self.curveHelper = C25519()
+    self.curveHelper = Curves.C25519()
 
     // Calls MixHash(prologue).
     self.symmetricState.mixHash(data: prologue)
@@ -178,6 +178,7 @@ public class HandshakeState {
 
 // Maintains the helper functions for the handshake state. Those function should be kept private.
 extension HandshakeState {
+
   // For "e": Sets e (which must be empty) to GENERATE_KEYPAIR(). Appends e.public_key to the
   // buffer. Calls MixHash(e.public_key).
   private func writeE() throws -> Data {
@@ -191,11 +192,13 @@ extension HandshakeState {
     self.symmetricState.mixHash(data: e.publicKey)
     return e.publicKey
   }
+
   // For "s": Appends EncryptAndHash(s.public_key) to the buffer.
   private func writeS() throws -> Data {
     let s = try self.getPublicKey(own: true, key: .s)
     return try self.symmetricState.encryptAndHash(plaintext: s)
   }
+
   // For "ee": Calls MixKey(DH(e, re)).
   private func writeEE() throws -> Data {
     let e = try self.getKeyPair(key: .e)
@@ -204,6 +207,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
+
   // For "es": Calls MixKey(DH(e, rs)) if initiator, MixKey(DH(s, re)) if responder.
   private func writeES() throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .e : .s)
@@ -212,6 +216,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
+
   // For "se": Calls MixKey(DH(s, re)) if initiator, MixKey(DH(e, rs)) if responder.
   private func writeSE() throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .s : .e)
@@ -220,6 +225,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
+
   // For "ss": Calls MixKey(DH(s, rs)).
   private func writeSS() throws -> Data {
     let s = try self.getKeyPair(key: .s)
@@ -228,6 +234,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return Data()
   }
+
   private func dispatchWriteToken(token: Token) throws -> Data {
     switch token {
     case .e:
@@ -258,6 +265,7 @@ extension HandshakeState {
     self.symmetricState.mixHash(data: re)
     return messageBuffer.suffix(messageBuffer.count - 32)
   }
+
   // For "s": Sets temp to the next DHLEN + 16 bytes of the message if HasKey() == True, or to
   // the next DHLEN bytes otherwise. Sets rs (which must be empty) to DecryptAndHash(temp).
   private func readS(_ messageBuffer: Data) throws -> Data {
@@ -272,6 +280,7 @@ extension HandshakeState {
     self.rs = rs
     return messageBuffer.suffix(messageBuffer.count - size)
   }
+
   // For "ee": Calls MixKey(DH(e, re)).
   private func readEE(_ messageBuffer: Data) throws -> Data {
     let e = try self.getKeyPair(key: .e)
@@ -280,6 +289,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
+
   // For "es": Calls MixKey(DH(e, rs)) if initiator, MixKey(DH(s, re)) if responder.
   private func readES(_ messageBuffer: Data) throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .e : .s)
@@ -288,6 +298,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
+
   // For "se": Calls MixKey(DH(s, re)) if initiator, MixKey(DH(e, rs)) if responder.
   private func readSE(_ messageBuffer: Data) throws -> Data {
     let keyPair = try self.getKeyPair(key: self.initiator ? .s : .e)
@@ -296,6 +307,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
+
   // For "ss": Calls MixKey(DH(s, rs)).
   private func readSS(_ messageBuffer: Data) throws -> Data {
     let s = try self.getKeyPair(key: .s)
@@ -304,6 +316,7 @@ extension HandshakeState {
     try self.symmetricState.mixKey(inputKeyMaterial: dh)
     return messageBuffer
   }
+
   private func dispatchReadToken(_ messageBuffer: Data, token: Token) throws -> Data {
     switch token {
     case .e:
@@ -325,6 +338,7 @@ extension HandshakeState {
 }
 
 extension HandshakeState {
+
   public func writeMessage(payload: Data) throws -> Data {
     if self.messagePatterns.count == 0 {
       throw HandshakeStateError.completedHandshake

--- a/Sources/SwiftNoise/States/SymmetricState.swift
+++ b/Sources/SwiftNoise/States/SymmetricState.swift
@@ -1,18 +1,18 @@
 import Foundation
-import CryptoSwift
+import Crypto
 
 // https://noiseprotocol.org/noise.html#the-symmetricstate-object
 public class SymmetricState {
   // ck: A chaining key of HASHLEN bytes.
-  var ck: Data
+  private var ck: Data
   // h: A hash output of HASHLEN bytes.
-  var h: Data
+  private var h: Data
   var cipherState: CipherState
 
-  var hashHelper: Hash
+  private let hashHelper: Hash
 
   init(protocolName: String) throws {
-    self.hashHelper = SHA256()
+    self.hashHelper = Hashes.SHA256()
 
     // If protocol_name is less than or equal to HASHLEN bytes in length,
     // sets h equal to protocol_name with zero bytes appended to make HASHLEN bytes.

--- a/Sources/SwiftNoise/States/SymmetricState.swift
+++ b/Sources/SwiftNoise/States/SymmetricState.swift
@@ -9,10 +9,10 @@ public class SymmetricState {
   private var h: Data
   var cipherState: CipherState
 
-  private let hashHelper: Hash
+  private let hashFunction: Hash
 
   init(protocolName: String) throws {
-    self.hashHelper = Hashes.SHA256()
+    self.hashFunction = Hashes.SHA256()
 
     // If protocol_name is less than or equal to HASHLEN bytes in length,
     // sets h equal to protocol_name with zero bytes appended to make HASHLEN bytes.
@@ -21,7 +21,7 @@ public class SymmetricState {
     if h.count <= 32 {
       self.h = h + Data(repeating: 0, count: 32 - h.count)
     } else {
-      self.h = self.hashHelper.hash(data: h)
+      self.h = self.hashFunction.hash(data: h)
     }
     // Sets ck = h.
     self.ck = self.h
@@ -32,7 +32,7 @@ public class SymmetricState {
 
   func mixKey(inputKeyMaterial: Data) throws {
     // Sets ck, temp_k = HKDF(ck, input_key_material, 2).
-    let hkdfOutput = try self.hashHelper.hkdf(chainingKey: self.ck, inputKeyMaterial: inputKeyMaterial, numOutputs: 2)
+    let hkdfOutput = try self.hashFunction.hkdf(chainingKey: self.ck, inputKeyMaterial: inputKeyMaterial, numOutputs: 2)
     self.ck = hkdfOutput[0]
     let tempK = hkdfOutput[1]
 
@@ -44,12 +44,12 @@ public class SymmetricState {
 
   func mixHash(data: Data) {
     // Sets h = HASH(h || data)
-    self.h = self.hashHelper.hash(data: self.h + data)
+    self.h = self.hashFunction.hash(data: self.h + data)
   }
 
   func mixKeyAndHash(inputKeyMaterial: Data) throws {
     // Sets ck, temp_h, temp_k = HKDF(ck, input_key_material, 3).
-    let hkdfOutput = try self.hashHelper.hkdf(chainingKey: self.ck, inputKeyMaterial: inputKeyMaterial, numOutputs: 3)
+    let hkdfOutput = try self.hashFunction.hkdf(chainingKey: self.ck, inputKeyMaterial: inputKeyMaterial, numOutputs: 3)
     self.ck = hkdfOutput[0]
     let tempH = hkdfOutput[1]
     let tempK = hkdfOutput[2]
@@ -86,7 +86,7 @@ public class SymmetricState {
 
   func split() throws -> (CipherState, CipherState) {
     // Sets temp_k1, temp_k2 = HKDF(ck, zerolen, 2).
-    let tempKs = try self.hashHelper.hkdf(chainingKey: self.ck, inputKeyMaterial: Data(), numOutputs: 2)
+    let tempKs = try self.hashFunction.hkdf(chainingKey: self.ck, inputKeyMaterial: Data(), numOutputs: 2)
     let tempK1 = tempKs[0]
     let tempK2 = tempKs[1]
 

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -180,7 +180,7 @@ let patterns: [HandshakePattern: PatternDetails] = [
   ),
 ]
 
-public func protocolComponents(name: String) throws -> (handshake: HandshakePattern, dh: Curve, cipher: Cipher, hash: Hash) {
+public func protocolComponents(name: String) throws -> (handshake: HandshakePattern, dh: DHFunction, cipher: Cipher, hash: Hash) {
   let components = name.components(separatedBy: "_")
 
   guard components.count == 5 else {
@@ -191,7 +191,7 @@ public func protocolComponents(name: String) throws -> (handshake: HandshakePatt
     throw ProtocolError.unsupported
   }
 
-  guard let curve = Curves.curve(named: components[2]) else {
+  guard let dhFunction = DHFunctions.dhFunction(named: components[2]) else {
     throw ProtocolError.unsupported
   }
 
@@ -203,5 +203,5 @@ public func protocolComponents(name: String) throws -> (handshake: HandshakePatt
     throw ProtocolError.unsupported
   }
 
-  return (handshake: handshake, dh: curve, cipher: cipher, hash: hash)
+  return (handshake: handshake, dh: dhFunction, cipher: cipher, hash: hash)
 }

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -179,3 +179,29 @@ let patterns: [HandshakePattern: PatternDetails] = [
     ]
   ),
 ]
+
+public func protocolComponents(name: String) throws -> (handshake: HandshakePattern, dh: Curve, cipher: Cipher, hash: Hash) {
+  let components = name.components(separatedBy: "_")
+
+  guard components.count == 5 else {
+    throw ProtocolError.invalid
+  }
+
+  guard let handshake = HandshakePattern(rawValue: components[1]) else {
+    throw ProtocolError.unsupported
+  }
+
+  guard let curve = Curves.curve(named: components[2]) else {
+    throw ProtocolError.unsupported
+  }
+
+  guard let cipher = Ciphers.cipher(named: components[3]) else {
+    throw ProtocolError.unsupported
+  }
+
+  guard let hash = Hashes.hash(named: components[4]) else {
+    throw ProtocolError.unsupported
+  }
+
+  return (handshake: handshake, dh: curve, cipher: cipher, hash: hash)
+}

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -4,8 +4,8 @@ public typealias PublicKey = Data
 public typealias SecretKey = Data
 
 public struct KeyPair {
-  public var publicKey: PublicKey
-  public var secretKey: SecretKey
+  public let publicKey: PublicKey
+  public let secretKey: SecretKey
 }
 
 public typealias Nonce = UInt64

--- a/Sources/SwiftNoise/SwiftNoiseError.swift
+++ b/Sources/SwiftNoise/SwiftNoiseError.swift
@@ -34,3 +34,8 @@ enum HashError: Error {
   case tooLittleOutputs
   case tooManyOutputs
 }
+
+enum ProtocolError: Error {
+  case invalid
+  case unsupported
+}

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftNoise
 
-func getKeyPair(dhFunction: Curve, secretKey: Data?) throws -> KeyPair? {
+func getKeyPair(dhFunction: DHFunction, secretKey: Data?) throws -> KeyPair? {
   guard let secret = secretKey else {
     return nil
   }

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -42,6 +42,14 @@ final class SwiftNoiseTests: XCTestCase {
     return json.vectors
   }
 
+    func testDHCurve25519() throws {
+        let privK = Data(hex: "4b9d66860c39de31492bdb3b090527bf66ef1ea75f105bb6f87328dfbb9fe337")
+        let pubK = Data(hex: "1ede233080a9305f658aeced07ef04ced370b5f1bba099b3abc39ec7b4f5a83f")
+
+        let kp1 = try DHFunctions.C25519().constructKeyPair(secretKey: privK)
+        XCTAssertEqual(kp1.publicKey.toHexString(), pubK.toHexString())
+    }
+
   func testSnowVectors() throws {
     guard let testVectors = try self.loadTestVectors() else {
       return XCTFail("Unable to load resource 'SnowTestVectors.json'")

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -57,10 +57,10 @@ final class SwiftNoiseTests: XCTestCase {
 
       print("Running test vector for \(testVector.protocolName)")
 
-      let handshakePattern = try getHandshakePatternFromProtocolName(protocolName: testVector.protocolName)
+      let protoComponents = try protocolComponents(name: testVector.protocolName)
 
       let initiatorState = try HandshakeState(
-        pattern: handshakePattern,
+        pattern: protoComponents.handshake,
         initiator: true,
         prologue: testVector.initPrologue,
         s: getKeyPair(curveHelper: curveHelper, secretKey: testVector.initStatic),
@@ -69,7 +69,7 @@ final class SwiftNoiseTests: XCTestCase {
       )
 
       let responderState = try HandshakeState(
-        pattern: handshakePattern,
+        pattern: protoComponents.handshake,
         initiator: false,
         prologue: testVector.respPrologue,
         s: getKeyPair(curveHelper: curveHelper, secretKey: testVector.respStatic),
@@ -97,37 +97,6 @@ final class SwiftNoiseTests: XCTestCase {
 
 enum TestError: Error {
   case invalidProtocolName
-}
-
-func protocolComponents(name: String) throws -> (handshake: HandshakePattern, dh: Curve, cipher: Cipher, hash: Hash) {
-  let components = name.components(separatedBy: "_")
-
-  guard components.count == 5 else {
-    throw TestError.invalidProtocolName
-  }
-
-  guard let handshake = HandshakePattern(rawValue: components[1]) else {
-    throw TestError.invalidProtocolName
-  }
-
-  guard let curve = Curves.curve(named: components[2]) else {
-    throw TestError.invalidProtocolName
-  }
-
-  guard let cipher = Ciphers.cipher(named: components[3]) else {
-    throw TestError.invalidProtocolName
-  }
-
-  guard let hash = Hashes.hash(named: components[4]) else {
-    throw TestError.invalidProtocolName
-  }
-
-  return (handshake: handshake, dh: curve, cipher: cipher, hash: hash)
-}
-
-func getHandshakePatternFromProtocolName(protocolName: String) throws -> HandshakePattern {
-  let components = try protocolComponents(name: protocolName)
-  return components.handshake
 }
 
 struct SnowTestVectors: Codable {

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 import SwiftNoise
 
-func getKeyPair(curveHelper: Curve, secretKey: Data?) -> KeyPair? {
+func getKeyPair(dhFunction: Curve, secretKey: Data?) -> KeyPair? {
   guard let secret = secretKey else {
     return nil
   }
-  return try? curveHelper.constructKeyPair(secretKey: secret)
+  return try? dhFunction.constructKeyPair(secretKey: secret)
 }
 
 final class SwiftNoiseTests: XCTestCase {
@@ -63,8 +63,8 @@ final class SwiftNoiseTests: XCTestCase {
         pattern: protoComponents.handshake,
         initiator: true,
         prologue: testVector.initPrologue,
-        s: getKeyPair(curveHelper: curveHelper, secretKey: testVector.initStatic),
-        e: getKeyPair(curveHelper: curveHelper, secretKey: testVector.initEphemeral),
+        s: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initStatic),
+        e: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initEphemeral),
         rs: testVector.initRemoteStatic
       )
 
@@ -72,8 +72,8 @@ final class SwiftNoiseTests: XCTestCase {
         pattern: protoComponents.handshake,
         initiator: false,
         prologue: testVector.respPrologue,
-        s: getKeyPair(curveHelper: curveHelper, secretKey: testVector.respStatic),
-        e: getKeyPair(curveHelper: curveHelper, secretKey: testVector.respEphemeral),
+        s: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respStatic),
+        e: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respEphemeral),
         rs: testVector.respRemoteStatic
       )
 

--- a/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
+++ b/Tests/SwiftNoiseTests/SwiftNoiseTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 import SwiftNoise
 
-func getKeyPair(dhFunction: Curve, secretKey: Data?) -> KeyPair? {
+func getKeyPair(dhFunction: Curve, secretKey: Data?) throws -> KeyPair? {
   guard let secret = secretKey else {
     return nil
   }
-  return try? dhFunction.constructKeyPair(secretKey: secret)
+  return try dhFunction.constructKeyPair(secretKey: secret)
 }
 
 final class SwiftNoiseTests: XCTestCase {
@@ -47,10 +47,8 @@ final class SwiftNoiseTests: XCTestCase {
       return XCTFail("Unable to load resource 'SnowTestVectors.json'")
     }
 
-    let curveHelper = Curves.C25519()
-
     for testVector in testVectors {
-      if !supportedCipherSuites.contains(testVector.protocolName) {
+      guard supportedCipherSuites.contains(testVector.protocolName) else {
         // print("unsupported cipher suite: \(testVector.protocolName)")
         continue
       }
@@ -63,8 +61,8 @@ final class SwiftNoiseTests: XCTestCase {
         pattern: protoComponents.handshake,
         initiator: true,
         prologue: testVector.initPrologue,
-        s: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initStatic),
-        e: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initEphemeral),
+        s: try getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initStatic),
+        e: try getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.initEphemeral),
         rs: testVector.initRemoteStatic
       )
 
@@ -72,8 +70,8 @@ final class SwiftNoiseTests: XCTestCase {
         pattern: protoComponents.handshake,
         initiator: false,
         prologue: testVector.respPrologue,
-        s: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respStatic),
-        e: getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respEphemeral),
+        s: try getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respStatic),
+        e: try getKeyPair(dhFunction: protoComponents.dh, secretKey: testVector.respEphemeral),
         rs: testVector.respRemoteStatic
       )
 


### PR DESCRIPTION
- Updates project to use [`apple/swift-crypto`](https://github.com/apple/swift-crypto) library
- Includes some other changes preparing new cipher suites
- Includes some helpers for use as a library

---
~We should complete [this issue](https://github.com/samueltangz/swift-noise-protocol/issues/18) before merging to ensure new updates have tests run against them.~