### PR TITLE
Update HandshakeState.swift

### DIFF
--- a/Sources/SwiftNoise/States/HandshakeState.swift
+++ b/Sources/SwiftNoise/States/HandshakeState.swift
@@ -363,8 +363,9 @@ extension HandshakeState {
       out += try self.dispatchWriteToken(token: token)
     }
     // Appends EncryptAndHash(payload) to the buffer.
-    out += try self.symmetricState.encryptAndHash(plaintext: payload)
-
+    if(!payload.isEmpty){
+     out += try self.symmetricState.encryptAndHash(plaintext: payload)
+    }
     // If there are no more message patterns returns two new CipherState objects by calling Split().
     if self.messagePatterns.isEmpty {
       return .handshakeComplete(out, try self.split())

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -4,8 +4,8 @@ public typealias PublicKey = Data
 public typealias SecretKey = Data
 
 public struct KeyPair: Codable {
-  public let publicKey: PublicKey
-  public let secretKey: SecretKey
+  public var publicKey: PublicKey
+  public var secretKey: SecretKey
 }
 
 public typealias Nonce = UInt64

--- a/Sources/SwiftNoise/Structs.swift
+++ b/Sources/SwiftNoise/Structs.swift
@@ -3,7 +3,7 @@ import Foundation
 public typealias PublicKey = Data
 public typealias SecretKey = Data
 
-public struct KeyPair {
+public struct KeyPair: Codable {
   public let publicKey: PublicKey
   public let secretKey: SecretKey
 }


### PR DESCRIPTION
Fixed unnecessary hash if there is no payload to hash.